### PR TITLE
inconsistent use of tabs and spaces in indentation

### DIFF
--- a/train.py
+++ b/train.py
@@ -97,8 +97,8 @@ for epoch in range(start_epoch, opt.niter + opt.niter_decay + 1):
             model.module.save('latest')            
             np.savetxt(iter_path, (epoch, epoch_iter), delimiter=',', fmt='%d')
        
-    # end of epoch 
-	iter_end_time = time.time()
+    # end of epoch
+    iter_end_time = time.time()
     print('End of epoch %d / %d \t Time Taken: %d sec' %
           (epoch, opt.niter + opt.niter_decay, time.time() - epoch_start_time))
 


### PR DESCRIPTION
flake8 testing of https://github.com/NVIDIA/pix2pixHD on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./train.py:101:28: E999 TabError: inconsistent use of tabs and spaces in indentation
	iter_end_time = time.time()
                           ^
```