### PR TITLE
Fix unexpected keyword argument

### DIFF
--- a/models/networks.py
+++ b/models/networks.py
@@ -41,7 +41,7 @@ def define_G(input_nc, output_nc, ngf, netG, n_downsample_global=3, n_blocks_glo
     print(netG)
     if len(gpu_ids) > 0:
         assert(torch.cuda.is_available())   
-        netG.cuda(device_id=gpu_ids[0])
+        netG.cuda(gpu_ids[0])
     netG.apply(weights_init)
     return netG
 


### PR DESCRIPTION
When testing using ./scripts/test_1024p.sh on a Nvidia Tesla K80 with CUDA Version 9.0.176 and cuDNN v7.0.5, I get this error:

Traceback (most recent call last):
File "test.py", line 20, in 
model = create_model(opt)
File "/home/conwayying/ml/pix2pixHD/models/models.py", line 8, in create_model
model.initialize(opt)
File "/home/conwayying/ml/pix2pixHD/models/pix2pixHD_model.py", line 33, in initialize
opt.n_blocks_local, opt.norm, gpu_ids=self.gpu_ids)
File "/home/conwayying/ml/pix2pixHD/models/networks.py", line 44, in define_G
netG.cuda(device_id=gpu_ids[0])
TypeError: cuda() got an unexpected keyword argument 'device_id'

Removing the device_id keyword argument fixes it.