### PR TITLE
Fixes webpage autorefresh and lowers default refresh rate

### DIFF
--- a/util/html.py
+++ b/util/html.py
@@ -4,7 +4,7 @@ import os
 
 
 class HTML:
-    def __init__(self, web_dir, title, reflesh=0):
+    def __init__(self, web_dir, title, refresh=0):
         self.title = title
         self.web_dir = web_dir
         self.img_dir = os.path.join(self.web_dir, 'images')
@@ -14,9 +14,9 @@ class HTML:
             os.makedirs(self.img_dir)
 
         self.doc = dominate.document(title=title)
-        if reflesh > 0:
+        if refresh > 0:
             with self.doc.head:
-                meta(http_equiv="reflesh", content=str(reflesh))
+                meta(http_equiv="refresh", content=str(refresh))
 
     def get_image_dir(self):
         return self.img_dir

--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -1,4 +1,4 @@
-### Copyright (C) 2017 NVIDIA Corporation. All rights reserved. 
+### Copyright (C) 2017 NVIDIA Corporation. All rights reserved.
 ### Licensed under the CC BY-NC-SA 4.0 license (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 import numpy as np
 import os
@@ -6,7 +6,7 @@ import ntpath
 import time
 from . import util
 from . import html
-import scipy.misc 
+import scipy.misc
 try:
     from StringIO import StringIO  # Python 2.7
 except ImportError:
@@ -66,7 +66,7 @@ class Visualizer():
                     util.save_image(image_numpy, img_path)
 
             # update website
-            webpage = html.HTML(self.web_dir, 'Experiment name = %s' % self.name, reflesh=1)
+            webpage = html.HTML(self.web_dir, 'Experiment name = %s' % self.name, refresh=5)
             for n in range(epoch, 0, -1):
                 webpage.add_header('epoch [%d]' % n)
                 ims = []
@@ -96,7 +96,7 @@ class Visualizer():
     # errors: dictionary of error labels and values
     def plot_current_errors(self, errors, step):
         if self.tf_log:
-            for tag, value in errors.items():            
+            for tag, value in errors.items():
                 summary = self.tf.Summary(value=[self.tf.Summary.Value(tag=tag, simple_value=value)])
                 self.writer.add_summary(summary, step)
 


### PR DESCRIPTION
Webpage with results didn't automatically refresh as it used the meta-tag "ref**l**esh" instead of "ref**r**esh".
Also, the default of refreshing every second seems a bit much, so lowered this to refresh every 5 seconds.