### PR TITLE
change scipy to PIL as scipy.io.imwrite is deprecated in 0.19 

### DIFF
--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -4,7 +4,7 @@ import ntpath
 import time
 from . import util
 from . import html
-import scipy.misc
+from PIL import Image
 try:
     from StringIO import StringIO  # Python 2.7
 except ImportError:
@@ -43,7 +43,7 @@ class Visualizer():
                     s = StringIO()
                 except:
                     s = BytesIO()
-                scipy.misc.toimage(image_numpy).save(s, format="jpeg")
+                Image.fromarray(image_numpy).save(s, format="jpeg")
                 # Create an Image object
                 img_sum = self.tf.Summary.Image(encoded_image_string=s.getvalue(), height=image_numpy.shape[0], width=image_numpy.shape[1])
                 # Create a Summary value


### PR DESCRIPTION
change scipy to PIL as scipy.io.imwrite is deprecated in 0.19 

and current version started to normalize all images so that min(data) become black and max(data) become white, making need for more code, etc. not cool.