### PR TITLE
Use math.gcd instead of fractions.gcd in order to be compatible with Python 3.9

### DIFF
--- a/train.py
+++ b/train.py
@@ -5,8 +5,8 @@ import torch
 from torch.autograd import Variable
 from collections import OrderedDict
 from subprocess import call
-import fractions
-def lcm(a,b): return abs(a * b)/fractions.gcd(a,b) if a and b else 0
+import math
+def lcm(a,b): return abs(a * b)/math.gcd(a,b) if a and b else 0
 
 from options.train_options import TrainOptions
 from data.data_loader import CreateDataLoader


### PR DESCRIPTION
When using the current version of the repository with Python 3.9, the fractions.gcd function can't be found. This is because this function was deprecated in Version 3.5 and has been moved to the math module: https://docs.python.org/3.8/library/fractions.html#fractions.gcd

This PR fixes the problem and works well with Python 3.9.